### PR TITLE
Bump react-scripts version to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^7.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Trying to update packages via `npm audit fix` was not working, after the message:
found 3 vulnerabilities (1 low, 2 high)

Bumped the version of react-scripts to v4.0.0 to resolve the above